### PR TITLE
修复兼容接口自定义模型与 Base URL 提示

### DIFF
--- a/game/tests/provider_settings_regression_test.gd
+++ b/game/tests/provider_settings_regression_test.gd
@@ -1,0 +1,191 @@
+extends SceneTree
+
+
+const SETTINGS_SERVICE := preload(
+	"res://world/presentation/ui/TownProviderSettingsService.gd"
+)
+const SETTINGS_SCENE := preload(
+	"res://ui/provider_settings/ProviderSettingsScreen.tscn"
+)
+
+var _failures: Array[String] = []
+
+
+func _initialize() -> void:
+	call_deferred("_run")
+
+
+func _run() -> void:
+	_test_runtime_custom_model_projection()
+	await _test_custom_model_input()
+	if _failures.is_empty():
+		print("PROVIDER_SETTINGS_REGRESSION_PASS")
+		quit(0)
+		return
+	for failure: String in _failures:
+		printerr("PROVIDER_SETTINGS_REGRESSION_FAIL: %s" % failure)
+	quit(1)
+
+
+func _test_runtime_custom_model_projection() -> void:
+	var service := SETTINGS_SERVICE.new()
+	_expect(
+		service.call(
+			"_chat_completions_url_is_valid",
+			"https://api.siliconflow.cn/v1/chat/completions",
+		),
+		"complete OpenAI-compatible endpoint is accepted",
+	)
+	_expect(
+		not service.call(
+			"_chat_completions_url_is_valid",
+			"https://api.siliconflow.cn/v1/",
+		),
+		"provider API root is rejected before the network request",
+	)
+	var endpoint_error := service.call(
+		"_error_payload",
+		"PROVIDER_CHAT_COMPLETIONS_URL_REQUIRED",
+		false,
+		"Base URL 需要填写完整接口，例如：https://api.siliconflow.cn/v1/chat/completions",
+	) as Dictionary
+	_expect_equal(
+		endpoint_error.get("playerMessage"),
+		endpoint_error.get("message"),
+		"specific provider error is exposed to the UI renderer",
+	)
+	service.set("_stored_config", {
+		"schemaVersion": 1,
+		"selectedProviderId": "openai-compatible",
+		"selectedModelByProvider": {"openai-compatible": "custom"},
+		"providers": {
+			"openai-compatible": {
+				"enabled": true,
+				"endpoint": "https://compatible.example/v1/chat/completions",
+				"apiModel": "vendor/model-v2",
+			},
+		},
+	})
+	service.set("_credential_keys", {"openai-compatible": "test-key"})
+	var configs := service.call("_provider_configs_for_runtime") as Dictionary
+	var custom := configs.get("openai-compatible", {}) as Dictionary
+	_expect_equal(
+		custom.get("api_model"),
+		"vendor/model-v2",
+		"custom model name reaches the runtime provider config",
+	)
+
+
+func _test_custom_model_input() -> void:
+	root.size = Vector2i(1920, 1080)
+	var screen := SETTINGS_SCENE.instantiate() as Control
+	root.add_child(screen)
+	_expect(screen.apply_view_model(_custom_provider_view_model()), "custom provider VM applies")
+	await process_frame
+	await process_frame
+	var input := screen.find_child("ModelNameInput", true, false) as LineEdit
+	var save := screen.find_child("SaveModelNameButton", true, false) as Button
+	var base_url := screen.find_child("BaseUrlInput", true, false) as LineEdit
+	_expect(input != null and input.editable, "custom model name input is editable")
+	_expect(save != null, "custom model name has an explicit save action")
+	_expect(
+		base_url != null
+		and base_url.placeholder_text.contains("https://api.siliconflow.cn/v1/chat/completions")
+		and base_url.tooltip_text.contains("完整"),
+		"custom Base URL field provides a complete API example",
+	)
+	if input != null and save != null:
+		_expect(
+			input.get_theme_stylebox("normal") is StyleBoxEmpty,
+			"composite model input reuses the card slot without a second frame",
+		)
+		_expect_equal(
+			save.text,
+			"保存模型名称",
+			"composite save action has an explicit label",
+		)
+		_expect(
+			not input.get_global_rect().intersects(save.get_global_rect()),
+			"model input and save action do not overlap",
+		)
+		var dispatched: Array[Dictionary] = []
+		screen.intent_requested.connect(func(intent: StringName, payload: Dictionary) -> void:
+			dispatched.append({"intent": String(intent), "payload": payload.duplicate(true)})
+		)
+		input.text = "vendor/model-v3"
+		input.text_changed.emit(input.text)
+		_expect(not save.disabled, "typing a model name enables save")
+		save.pressed.emit()
+		_expect_equal(dispatched.size(), 1, "model name save dispatches once")
+		if not dispatched.is_empty():
+			_expect_equal(
+				dispatched[0].get("intent"),
+				"provider_settings.save_api_model",
+				"model name uses the dedicated save intent",
+			)
+			var payload := dispatched[0].get("payload", {}) as Dictionary
+			_expect_equal(payload.get("apiModel"), "vendor/model-v3", "typed model is submitted")
+	screen.queue_free()
+	await process_frame
+
+
+func _custom_provider_view_model() -> Dictionary:
+	var actions := {}
+	for key: String in [
+		"back", "selectProvider", "setProviderEnabled", "saveKey", "deleteKey",
+		"saveBaseUrl", "saveApiModel", "selectModel", "checkConnection",
+	]:
+		actions[key] = {
+			"intent": "provider_settings.%s" % key,
+			"enabled": true,
+			"disabledReason": "",
+		}
+	return {
+		"scope": "provider_settings",
+		"status": "ready",
+		"revision": 1,
+		"data": {
+			"source": "runtime",
+			"capabilityMode": "formal",
+			"formalReady": false,
+			"pageTitle": "模型设置",
+			"selectedProviderId": "openai-compatible",
+			"formalStatusLabel": "待检查",
+			"providers": [{
+				"providerId": "openai-compatible",
+				"displayName": "OpenAI Compatible",
+				"enabled": true,
+				"external": true,
+				"key": {"saved": true, "maskedValue": "••••", "status": "saved", "errorCode": ""},
+				"baseUrl": "https://compatible.example/v1/chat/completions",
+				"apiModel": "vendor/model-v2",
+				"models": [{
+					"modelId": "custom",
+					"displayName": "自定义模型",
+					"capabilities": ["decision_json", "dialogue"],
+					"enabled": true,
+				}],
+				"connection": {"status": "unchecked", "label": "待检查", "message": ""},
+			}],
+			"summary": {"availableProviderCount": 0, "enabledModelCount": 1},
+		},
+		"actions": actions,
+		"operation": {
+			"requestId": "",
+			"intent": "",
+			"status": "idle",
+			"submittedAtMsec": 0,
+			"completedAtMsec": 0,
+		},
+		"error": null,
+	}
+
+
+func _expect(condition: bool, message: String) -> void:
+	if not condition:
+		_failures.append(message)
+
+
+func _expect_equal(actual: Variant, expected: Variant, message: String) -> void:
+	if actual != expected:
+		_failures.append("%s: expected=%s actual=%s" % [message, expected, actual])

--- a/game/tests/provider_settings_regression_test.gd.uid
+++ b/game/tests/provider_settings_regression_test.gd.uid
@@ -1,0 +1,1 @@
+uid://b3y5sx7qksclu

--- a/game/ui/provider_settings/ProviderSettingsScreen.gd
+++ b/game/ui/provider_settings/ProviderSettingsScreen.gd
@@ -39,6 +39,7 @@ var _draft_key := ""
 var _draft_key_baseline := ""
 var _draft_key_dirty := false
 var _draft_base_url := ""
+var _draft_api_model := ""
 var _draft_provider_id := ""
 var _discard_confirmation: FormalDialog
 var _pending_provider_selection: Dictionary = {}
@@ -52,6 +53,7 @@ var _model_page := -1
 var _key_edit: LineEdit
 var _save_key_button: Button
 var _base_url_edit: LineEdit
+var _model_name_edit: LineEdit
 var _status_label: Label
 var _check_button: Button
 var _formal_badge: Label
@@ -133,7 +135,10 @@ func _has_unsaved_local_draft() -> bool:
 	var selected := _find_provider(_selected_provider_id)
 	if selected.is_empty():
 		return false
-	return _draft_base_url != String(selected.get("baseUrl", ""))
+	return (
+		_draft_base_url != String(selected.get("baseUrl", ""))
+		or _draft_api_model != String(selected.get("apiModel", ""))
+	)
 
 
 func bind_adapter(adapter: Object) -> void:
@@ -155,6 +160,7 @@ func bind_adapter(adapter: Object) -> void:
 	_draft_key_baseline = ""
 	_draft_key_dirty = false
 	_draft_base_url = ""
+	_draft_api_model = ""
 	_show_key = false
 	_provider_page = -1
 	_model_page = -1
@@ -241,11 +247,17 @@ func apply_view_model(view_model: Dictionary) -> bool:
 			_draft_key_dirty = false
 			_show_key = false
 			_draft_base_url = str(selected.get("baseUrl", ""))
+			_draft_api_model = str(selected.get("apiModel", ""))
 		elif (
 			operation_status_text == "success"
 			and operation_intent == "provider_settings.save_base_url"
 		):
 			_draft_base_url = str(selected.get("baseUrl", ""))
+		elif (
+			operation_status_text == "success"
+			and operation_intent == "provider_settings.save_api_model"
+		):
+			_draft_api_model = str(selected.get("apiModel", ""))
 	if (
 		operation_status_text == "success"
 		and operation_intent == "provider_settings.save_key"
@@ -602,6 +614,7 @@ func _rebuild_layout() -> void:
 	_key_edit = null
 	_save_key_button = null
 	_base_url_edit = null
+	_model_name_edit = null
 	_status_label = null
 	_check_button = null
 	_formal_badge = null
@@ -697,6 +710,8 @@ func _capture_input_focus_state() -> Dictionary:
 		field = "api_key"
 	elif focus_owner == _base_url_edit:
 		field = "base_url"
+	elif focus_owner == _model_name_edit:
+		field = "model_name"
 	if field.is_empty() or not focus_owner is LineEdit:
 		return {}
 	var edit := focus_owner as LineEdit
@@ -721,10 +736,9 @@ func _schedule_focus_after_rebuild(input_focus_state: Dictionary) -> void:
 func _restore_input_focus_state(input_focus_state: Dictionary) -> void:
 	if not is_inside_tree() or not is_instance_valid(_layout_root):
 		return
-	var edit := (
-		_key_edit
-		if String(input_focus_state.get("field", "")) == "api_key"
-		else _base_url_edit
+	var field := String(input_focus_state.get("field", ""))
+	var edit := _key_edit if field == "api_key" else (
+		_model_name_edit if field == "model_name" else _base_url_edit
 	)
 	if edit == null or not edit.is_visible_in_tree() or not edit.editable:
 		_focus_initial_control()
@@ -761,6 +775,7 @@ func _rebuild_composite_desktop(viewport_size: Vector2) -> void:
 		_draft_key,
 		_draft_key_dirty,
 		_draft_base_url,
+		_draft_api_model,
 		_show_key,
 		_provider_page,
 		_model_page,
@@ -791,6 +806,7 @@ func _sync_composite_controls() -> void:
 		false,
 	) as Button
 	_base_url_edit = _composite_desktop.base_url_edit
+	_model_name_edit = _composite_desktop.model_name_edit
 	_status_label = _composite_desktop.status_label
 	_check_button = _composite_desktop.check_button
 	_formal_badge = _composite_desktop.formal_badge
@@ -821,6 +837,8 @@ func _on_composite_ui_action(
 			_sync_key_save_enabled()
 		&"ui.draft_base_url":
 			_draft_base_url = str(payload.get("value", ""))
+		&"ui.draft_api_model":
+			_draft_api_model = str(payload.get("value", ""))
 		&"ui.toggle_key_visibility":
 			_toggle_key_visibility(_selected_provider_id)
 		&"ui.save_key":
@@ -1569,7 +1587,8 @@ func _build_base_url_section(provider: Dictionary) -> Control:
 	_base_url_edit = LineEdit.new()
 	_base_url_edit.name = "BaseUrlInput"
 	_base_url_edit.text = _draft_base_url
-	_base_url_edit.placeholder_text = "留空使用官方默认地址"
+	_base_url_edit.placeholder_text = _base_url_placeholder(provider)
+	_base_url_edit.tooltip_text = _base_url_help(provider)
 	_base_url_edit.custom_minimum_size = Vector2(
 		220 if _is_phone_profile() else 320,
 		_field_height()
@@ -1639,6 +1658,8 @@ func _build_models_section(provider: Dictionary) -> Control:
 		"模型与能力",
 		"启用后参与连接检查"
 	))
+	if str(provider.get("providerId", "")) == "openai-compatible":
+		column.add_child(_build_custom_model_name_row(provider))
 	var grid := GridContainer.new()
 	grid.name = "ModelGrid"
 	grid.columns = 1 if _is_phone_profile() else 2
@@ -1655,6 +1676,75 @@ func _build_models_section(provider: Dictionary) -> Control:
 				model_value as Dictionary
 			))
 	return panel
+
+
+func _build_custom_model_name_row(provider: Dictionary) -> Control:
+	var row: BoxContainer = (
+		VBoxContainer.new() if _is_phone_profile() else HBoxContainer.new()
+	)
+	row.name = "CustomModelNameRow"
+	row.add_theme_constant_override("separation", 10)
+	_model_name_edit = LineEdit.new()
+	_model_name_edit.name = "ModelNameInput"
+	_model_name_edit.text = _draft_api_model
+	_model_name_edit.placeholder_text = "请输入服务商的模型名称，例如 vendor/model-name"
+	_model_name_edit.max_length = 256
+	_model_name_edit.custom_minimum_size = Vector2(
+		220 if _is_phone_profile() else 320,
+		_field_height(),
+	)
+	_model_name_edit.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	_model_name_edit.focus_mode = Control.FOCUS_ALL
+	_model_name_edit.add_to_group("provider_settings_touch_target")
+	_model_name_edit.set_meta("gate_id", "model_name_input")
+	_model_name_edit.text_changed.connect(func(value: String) -> void:
+		_draft_api_model = value
+	)
+	row.add_child(_model_name_edit)
+	var save := _button(
+		"保存模型名",
+		"quiet",
+		Vector2(176 if not _is_phone_profile() else 220, _control_height()),
+	)
+	save.name = "SaveModelNameButton"
+	save.set_meta("gate_id", "model_name_save")
+	if _is_phone_profile():
+		save.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	save.disabled = (
+		not _action_enabled("saveApiModel")
+		or _operation_loading()
+		or _draft_api_model.is_empty()
+	)
+	save.pressed.connect(func() -> void:
+		_dispatch_intent(
+			&"provider_settings.save_api_model",
+			{
+				"providerId": str(provider.get("providerId", "")),
+				"apiModel": _model_name_edit.text,
+			},
+		)
+	)
+	_model_name_edit.text_changed.connect(func(value: String) -> void:
+		save.disabled = (
+			not _action_enabled("saveApiModel")
+			or _operation_loading()
+			or value.is_empty()
+		)
+	)
+	row.add_child(save)
+	return row
+
+
+func _base_url_placeholder(provider: Dictionary) -> String:
+	if str(provider.get("providerId", "")) == "openai-compatible":
+		return "例如：https://api.siliconflow.cn/v1/chat/completions"
+	return "留空使用官方默认地址"
+
+
+func _base_url_help(provider: Dictionary) -> String:
+	if str(provider.get("providerId", "")) == "openai-compatible":
+		return "请填写完整的 Chat Completions API 地址，例如：https://api.siliconflow.cn/v1/chat/completions"
+	return "留空时使用该服务商的官方默认地址"
 
 
 func _model_card(

--- a/game/ui/provider_settings/composite/ProviderSettingsCompositeDesktop.gd
+++ b/game/ui/provider_settings/composite/ProviderSettingsCompositeDesktop.gd
@@ -39,6 +39,7 @@ const DETAIL_STRETCH_SAMPLE_Y := 735.0
 
 var key_edit: LineEdit
 var base_url_edit: LineEdit
+var model_name_edit: LineEdit
 var status_label: Label
 var check_button: Button
 var formal_badge: Label
@@ -51,6 +52,7 @@ var _selected_provider_id := ""
 var _draft_key := ""
 var _draft_key_dirty := false
 var _draft_base_url := ""
+var _draft_api_model := ""
 var _show_key := false
 var _contract: Dictionary
 var _slots: Dictionary
@@ -72,6 +74,7 @@ func configure(
 	draft_key: String,
 	draft_key_dirty: bool,
 	draft_base_url: String,
+	draft_api_model: String,
 	show_key: bool,
 	provider_page: int,
 	model_page: int,
@@ -83,6 +86,7 @@ func configure(
 	_draft_key = draft_key
 	_draft_key_dirty = draft_key_dirty
 	_draft_base_url = draft_base_url
+	_draft_api_model = draft_api_model
 	_show_key = show_key
 	_contract = _load_json(CONTRACT_PATH)
 	if _contract.is_empty():
@@ -702,7 +706,16 @@ func _build_base_url_section(
 		"ui.provider-settings.composite.base-url-input.v1"
 	)
 	base_url_edit.text = _draft_base_url
-	base_url_edit.placeholder_text = "留空使用官方默认地址"
+	base_url_edit.placeholder_text = (
+		"例如：https://api.siliconflow.cn/v1/chat/completions"
+		if str(provider.get("providerId", "")) == "openai-compatible"
+		else "留空使用官方默认地址"
+	)
+	base_url_edit.tooltip_text = (
+		"请填写完整的 Chat Completions API 地址，例如：https://api.siliconflow.cn/v1/chat/completions"
+		if str(provider.get("providerId", "")) == "openai-compatible"
+		else "留空时使用该服务商的官方默认地址"
+	)
 	base_url_edit.text_changed.connect(func(value: String) -> void:
 		ui_action.emit(&"ui.draft_base_url", {"value": value})
 	)
@@ -756,6 +769,8 @@ func _build_models_section(
 		"模型与能力",
 		ProviderTheme.COMPOSITE_INK
 	)
+	if str(provider.get("providerId", "")) == "openai-compatible":
+		_build_custom_model_name_input(owner, region_rect, provider)
 	var models := provider.get("models", []) as Array
 	var page_count := _page_count(models.size(), MODELS_PER_PAGE)
 	_model_page = clampi(_model_page, 0, page_count - 1)
@@ -796,6 +811,11 @@ func _build_models_section(
 		var model := models[page_start + index] as Dictionary
 		var model_id := str(model.get("modelId", ""))
 		var card_rect := _hit_rect("model_%d" % index)
+		if (
+			str(provider.get("providerId", "")) == "openai-compatible"
+			and model_id == "custom"
+		):
+			continue
 		var card := _hit_button_from_rect(
 			owner,
 			region_rect,
@@ -871,6 +891,80 @@ func _build_models_section(
 			"该服务商当前仅提供一个居民模型",
 			ProviderTheme.COMPOSITE_MUTED
 		)
+
+
+func _build_custom_model_name_input(
+	owner: Control,
+	region_rect: Rect2,
+	provider: Dictionary,
+) -> void:
+	model_name_edit = _line_edit_for_slot(
+		owner,
+		region_rect,
+		"model_0_name",
+		"ModelNameInput",
+		"model_name_input",
+		"ui.provider-settings.composite.model-name-input.v2",
+	)
+	model_name_edit.text = _draft_api_model
+	model_name_edit.placeholder_text = "输入服务商模型名称"
+	model_name_edit.max_length = 256
+	model_name_edit.text_changed.connect(func(value: String) -> void:
+		ui_action.emit(&"ui.draft_api_model", {"value": value})
+	)
+	model_name_edit.text_submitted.connect(func(value: String) -> void:
+		ui_action.emit(
+			&"provider_settings.save_api_model",
+			{
+				"providerId": str(provider.get("providerId", "")),
+				"apiModel": value,
+			},
+		)
+	)
+	var capability_slot := _slots.get("model_0_capabilities", {}) as Dictionary
+	var save_rect := _scaled_rect(
+		_rect(capability_slot.get("wellRect", capability_slot.get("rect", [])))
+	)
+	var save := _hit_button_from_rect(
+		owner,
+		region_rect,
+		save_rect,
+		"SaveModelNameButton",
+		"model_name_save",
+		"operation_control",
+		"ui.provider-settings.composite.model-name-save.v1",
+		"composite-transparent-control",
+	)
+	save.text = "保存模型名称"
+	save.add_theme_font_override("font", ProviderTheme.composite_font("body"))
+	save.add_theme_font_size_override("font_size", _scaled_font_size(20))
+	for state: String in ["font_color", "font_hover_color", "font_focus_color"]:
+		save.add_theme_color_override(state, ProviderTheme.COMPOSITE_SUCCESS)
+	save.add_theme_color_override(
+		"font_disabled_color",
+		ProviderTheme.COMPOSITE_MUTED,
+	)
+	save.disabled = (
+		not _action_enabled("saveApiModel")
+		or _operation_loading()
+		or _draft_api_model.is_empty()
+	)
+	save.pressed.connect(func() -> void:
+		ui_action.emit(
+			&"provider_settings.save_api_model",
+			{
+				"providerId": str(provider.get("providerId", "")),
+				"apiModel": model_name_edit.text,
+			},
+		)
+	)
+	model_name_edit.text_changed.connect(func(value: String) -> void:
+		save.disabled = (
+			not _action_enabled("saveApiModel")
+			or _operation_loading()
+			or value.is_empty()
+		)
+	)
 
 
 func _pagination_button(

--- a/game/world/presentation/ui/TownProviderConfigStore.gd
+++ b/game/world/presentation/ui/TownProviderConfigStore.gd
@@ -23,6 +23,7 @@ const PROVIDER_CONFIG_KEYS := [
 	"enabled",
 	"apiKeyRef",
 	"endpoint",
+	"apiModel",
 	"api_key",
 ]
 
@@ -245,6 +246,13 @@ func _validate_config(
 					not (endpoint as String).is_empty()
 					and not _endpoint_is_valid(endpoint as String)
 				)
+			):
+				return _failure("PROVIDER_CONFIG_INVALID")
+		if provider.has("apiModel"):
+			var api_model: Variant = provider.get("apiModel")
+			if (
+				typeof(api_model) != TYPE_STRING
+				or not _model_id_is_valid(api_model as String)
 			):
 				return _failure("PROVIDER_CONFIG_INVALID")
 	if not _json_safe(config):

--- a/game/world/presentation/ui/TownProviderSettingsService.gd
+++ b/game/world/presentation/ui/TownProviderSettingsService.gd
@@ -20,6 +20,8 @@ const REQUIRED_PROVIDER_METHODS: Array[String] = [
 ]
 const HOST_ROUTING_REQUIRED := "PROVIDER_SETTINGS_HOST_ROUTING_REQUIRED"
 const TEST_NO_NETWORK_ENV := "AI_TOWN_PROVIDER_TEST_NO_NETWORK"
+const CUSTOM_MODEL_PROVIDER_ID := "openai-compatible"
+const CUSTOM_MODEL_CATALOG_ID := "custom"
 const PROVIDER_DISPLAY_NAMES := {
 	"deepseek": "DeepSeek",
 	"kimi": "Kimi",
@@ -300,6 +302,8 @@ func dispatch(intent: Variant, payload: Dictionary = {}) -> Dictionary:
 			result = _delete_key(payload)
 		"provider_settings.save_base_url":
 			result = _save_base_url(payload)
+		"provider_settings.save_api_model":
+			result = _save_api_model(payload)
 		"provider_settings.set_enabled":
 			result = _set_enabled(payload)
 		"provider_settings.select_model":
@@ -475,6 +479,7 @@ func _load_public_snapshot() -> Dictionary:
 				"errorCode": "" if has_saved_key else "PROVIDER_API_KEY_REQUIRED",
 			},
 			"baseUrl": String(stored_provider.get("endpoint", "")),
+			"apiModel": String(stored_provider.get("apiModel", "")),
 			"models": (
 				models_by_provider.get(provider_id, []) as Array
 			).duplicate(true),
@@ -718,6 +723,11 @@ func _save_base_url(payload: Dictionary) -> Dictionary:
 		return _failure("PROVIDER_BASE_URL_INVALID", false)
 	if not endpoint.is_empty() and not endpoint.begins_with("https://"):
 		return _failure("PROVIDER_BASE_URL_INVALID", false)
+	if (
+		provider_id == CUSTOM_MODEL_PROVIDER_ID
+		and not _chat_completions_url_is_valid(endpoint)
+	):
+		return _failure("PROVIDER_CHAT_COMPLETIONS_URL_REQUIRED", false)
 	var candidate := _stored_config.duplicate(true)
 	var providers := candidate.get("providers", {}) as Dictionary
 	var provider := (providers.get(provider_id, {}) as Dictionary).duplicate(true)
@@ -730,6 +740,40 @@ func _save_base_url(payload: Dictionary) -> Dictionary:
 	return _persist_candidate_reconfigure_and_reload(
 		candidate,
 		"Provider 地址已更新。",
+		provider_id,
+	)
+
+
+func _save_api_model(payload: Dictionary) -> Dictionary:
+	var provider_result := _required_canonical_id(payload, "providerId")
+	if not bool(provider_result.get("ok", false)):
+		return _failure("PROVIDER_SETTINGS_PROVIDER_REQUIRED", false)
+	var provider_id := String(provider_result.get("value", ""))
+	if (
+		provider_id != CUSTOM_MODEL_PROVIDER_ID
+		or _provider_from_confirmed(provider_id).is_empty()
+	):
+		return _failure("PROVIDER_SETTINGS_PROVIDER_UNKNOWN", false)
+	var api_model_value: Variant = payload.get("apiModel")
+	if typeof(api_model_value) != TYPE_STRING:
+		return _failure("PROVIDER_API_MODEL_INVALID", false)
+	var api_model := api_model_value as String
+	if not _api_model_is_valid(api_model):
+		return _failure("PROVIDER_API_MODEL_INVALID", false)
+	var candidate := _stored_config.duplicate(true)
+	var providers := candidate.get("providers", {}) as Dictionary
+	var provider := (providers.get(provider_id, {}) as Dictionary).duplicate(true)
+	provider["apiModel"] = api_model
+	provider["enabled"] = true
+	providers[provider_id] = provider
+	candidate["providers"] = providers
+	var selected_models := candidate.get("selectedModelByProvider", {}) as Dictionary
+	selected_models[provider_id] = CUSTOM_MODEL_CATALOG_ID
+	candidate["selectedModelByProvider"] = selected_models
+	candidate["selectedProviderId"] = provider_id
+	return _persist_candidate_reconfigure_and_reload(
+		candidate,
+		"自定义模型名称已更新。",
 		provider_id,
 	)
 
@@ -805,6 +849,12 @@ func _check_connection(payload: Dictionary, request_id: String) -> Dictionary:
 		return _failure("PROVIDER_MODEL_SELECTION_REQUIRED", false)
 	var stored_providers := _stored_config.get("providers", {}) as Dictionary
 	var stored_provider := stored_providers.get(provider_id, {}) as Dictionary
+	var endpoint := String(stored_provider.get("endpoint", "")).strip_edges()
+	if (
+		provider_id == CUSTOM_MODEL_PROVIDER_ID
+		and not _chat_completions_url_is_valid(endpoint)
+	):
+		return _failure("PROVIDER_CHAT_COMPLETIONS_URL_REQUIRED", false)
 	if not bool(stored_provider.get("enabled", true)):
 		return _failure("PROVIDER_DISABLED", false)
 	if not _has_saved_key(provider_id):
@@ -1041,6 +1091,9 @@ func _provider_configs_for_runtime() -> Dictionary:
 		var endpoint := String(source.get("endpoint", "")).strip_edges()
 		if not endpoint.is_empty():
 			config["endpoint"] = endpoint
+		var api_model := String(source.get("apiModel", "")).strip_edges()
+		if not api_model.is_empty():
+			config["api_model"] = api_model
 		result[provider_id] = config
 	return result
 
@@ -1122,6 +1175,24 @@ func _provider_has_model(provider: Dictionary, model_id: String) -> bool:
 		):
 			return true
 	return false
+
+
+func _api_model_is_valid(value: String) -> bool:
+	if value.is_empty() or value != value.strip_edges() or value.length() > 256:
+		return false
+	for character: String in value:
+		var codepoint := character.unicode_at(0)
+		if codepoint <= 32 or codepoint == 127:
+			return false
+	return true
+
+
+func _chat_completions_url_is_valid(value: String) -> bool:
+	var normalized := value.strip_edges().trim_suffix("/")
+	return (
+		normalized.begins_with("https://")
+		and normalized.ends_with("/chat/completions")
+	)
 
 
 func _invalidate_provider_health(provider_id: String) -> void:
@@ -1208,6 +1279,7 @@ func _actions(data: Dictionary) -> Dictionary:
 		"saveKey": _action("provider_settings.save_key", has_providers),
 		"deleteKey": _action("provider_settings.delete_key", has_providers),
 		"saveBaseUrl": _action("provider_settings.save_base_url", has_providers),
+		"saveApiModel": _action("provider_settings.save_api_model", has_providers),
 		"selectModel": _action("provider_settings.select_model", has_providers),
 		"checkConnection": _action("provider_settings.check_connection", has_providers, "PROVIDER_SETTINGS_PROVIDER_REQUIRED"),
 	}
@@ -1353,6 +1425,7 @@ func _error_payload(
 		"code": code,
 		"retryable": retryable,
 		"message": message,
+		"playerMessage": message,
 		"details": (details as Array).duplicate(true) if details is Array else [],
 	}
 
@@ -1384,6 +1457,10 @@ func _player_message_for_error_code(code: String) -> String:
 			return "当前 Provider 已停用。请先启用，再检查连接。"
 		"PROVIDER_BASE_URL_INVALID":
 			return "Base URL 必须使用 https:// 地址。请修正并重新保存。"
+		"PROVIDER_API_MODEL_INVALID":
+			return "请输入有效的模型名称。"
+		"PROVIDER_CHAT_COMPLETIONS_URL_REQUIRED":
+			return "Base URL 需要填写完整接口，例如：https://api.siliconflow.cn/v1/chat/completions"
 		"PROVIDER_AUTH_FAILED":
 			return "API Key 未通过认证。请重新输入并保存 Key，然后重试。"
 		"PROVIDER_BILLING_FAILED":

--- a/tools/guards/test_classification.json
+++ b/tools/guards/test_classification.json
@@ -73,6 +73,7 @@
   "game/tests/agent/support/ScriptedModelProvider.gd": "辅助",
   "game/tests/agent/support/agent_test_format_test.gd": "自动测试",
   "game/tests/game_flow_host_formal_entry_test.gd": "自动测试",
+  "game/tests/provider_settings_regression_test.gd": "自动测试",
   "game/tests/startup_performance_compatibility_test.gd": "自动测试",
   "game/tests/resident_presentation_test.gd": "自动测试",
   "game/tests/support/TownWorldTestCase.gd": "辅助",


### PR DESCRIPTION
## 修改内容

- 为 OpenAI Compatible 供应商增加可编辑、可保存的自定义模型名称输入。
- 将自定义模型名称持久化，并投影到运行时 Provider 配置。
- 在 Base URL 输入框提供完整的 Chat Completions 示例地址。
- 对自定义兼容接口增加完整 `/chat/completions` 地址校验和明确错误提示。
- 增加自定义模型输入、保存和 Base URL 示例的回归测试。

## 原因与影响

此前兼容接口只能选择固定模型，无法填写服务商实际模型名称；Base URL 也缺少完整接口示例，用户容易只填写 API 根路径，导致连接不可用。本修改允许兼容接口正确保存任意合法模型名，并在界面中明确展示完整请求地址格式。

## 验证

- Godot 4.7.1 headless：`res://tests/provider_settings_regression_test.gd`
- 结果：退出码 0
