### PR TITLE
fix Windows session cleanup

### DIFF
--- a/game/world/presentation/session/TownSessionSaveStore.gd
+++ b/game/world/presentation/session/TownSessionSaveStore.gd
@@ -2359,6 +2359,9 @@ func _remove_tree(path: String) -> Error:
 		var child_error := _remove_tree(_join(path, directory_name))
 		if child_error != OK:
 			return child_error
+	# Windows will not remove a directory while this DirAccess still owns an
+	# open handle to it. Release the iterator before deleting the directory.
+	directory = null
 	return DirAccess.remove_absolute(absolute)
 
 


### PR DESCRIPTION
## What changed

- Release the active `DirAccess` iterator before deleting a session-save directory tree.

## Why

On Windows, the open directory handle prevented `DirAccess.remove_absolute()` from removing the directory. New-game/continue cleanup could then fail with `SESSION_SAVE_STORE_CLEANUP_FAILED`, blocking entry into the town.

## Impact

- Session cleanup can complete on Windows.
- New-game and continue flows are no longer blocked by the retained directory handle.

## Validation

- `Godot_v4.7.1-stable_win64.exe --headless --path . --script res://tests/game_flow_host_formal_entry_test.gd`
