### PR TITLE
Enforce LF line endings for cross-platform checkouts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf


### PR DESCRIPTION
## What changed

- add a root `.gitattributes`
- let Git auto-detect text files and always check them out with LF

## Why

On Windows, a global `core.autocrlf=true` converts tracked JSON and GDScript files to CRLF because the repository has no line-ending policy.

That breaks the raw SHA-256 checks in `whitebody_freeze_manifest_v2.json`, causing resident presentation startup to fail with `PRESENTATION_WORLD_SNAPSHOT_APPLY_FAILED`. It also changes newlines inside multiline GDScript prompt strings, causing `agent_life_prompt_test.gd` to fail.

`text=auto` leaves binary assets untouched, while `eol=lf` keeps the text bytes required by the repository's runtime contracts and tests.

Fixes #24.

## Validation

- RED before the change: `git -c core.autocrlf=true check-attr eol` returned `unspecified`
- GREEN after the change: the same check returns `lf`
- simulated checkout with `core.autocrlf=true` preserved the expected rig contract SHA-256: `e8d2ca75cf8e4fc03bc68f0333f8f39fe20bfa04526d9271926277fa73e5e038`
- `AGENT_DEBUG_LAB_TEST_PASS`
- `AGENT_LIFE_PROMPT_PASS`
- `git diff --cached --check`
