### PR TITLE
feat:添加了对Ollama部分本地模型和部分云模型的支持

### DIFF
--- a/game/agent/model/ModelProviderCatalog.gd
+++ b/game/agent/model/ModelProviderCatalog.gd
@@ -8,6 +8,8 @@ const AlibabaBailianModelProviderScript := preload("res://agent/model/AlibabaBai
 const KimiModelProviderScript := preload("res://agent/model/KimiModelProvider.gd")
 const ZhipuGLMModelProviderScript := preload("res://agent/model/ZhipuGLMModelProvider.gd")
 const XiaomiMiMoModelProviderScript := preload("res://agent/model/XiaomiMiMoModelProvider.gd")
+const OllamaModelProviderScript := preload("res://agent/model/OllamaModelProvider.gd")
+const OllamaCloudModelProviderScript := preload("res://agent/model/OllamaCloudModelProvider.gd")
 const GenericOpenAICompatibleModelProviderScript := preload(
 	"res://agent/model/GenericOpenAICompatibleModelProvider.gd"
 )
@@ -32,6 +34,8 @@ func _init(include_defaults := true) -> void:
 	_register_provider_with_models(KimiModelProviderScript, _create_kimi)
 	_register_provider_with_models(ZhipuGLMModelProviderScript, _create_zhipu_glm)
 	_register_provider_with_models(XiaomiMiMoModelProviderScript, _create_xiaomi_mimo)
+	_register_provider_with_models(OllamaModelProviderScript, _create_ollama)
+	_register_provider_with_models(OllamaCloudModelProviderScript, _create_ollama_cloud)
 	_register_provider_with_models(
 		GenericOpenAICompatibleModelProviderScript,
 		_create_openai_compatible,
@@ -292,6 +296,11 @@ func _create_zhipu_glm(request_host: Node, config: Dictionary) -> RefCounted:
 func _create_xiaomi_mimo(request_host: Node, config: Dictionary) -> RefCounted:
 	return XiaomiMiMoModelProviderScript.new(request_host, null, config)
 
+func _create_ollama(request_host: Node, config: Dictionary) -> RefCounted:
+	return OllamaModelProviderScript.new(request_host, null, config)
+	
+func _create_ollama_cloud(request_host: Node, config: Dictionary) -> RefCounted:
+	return OllamaCloudModelProviderScript.new(request_host, null, config)
 
 func _create_kimi(request_host: Node, config: Dictionary) -> RefCounted:
 	return KimiModelProviderScript.new(request_host, null, config)

--- a/game/agent/model/OllamaCloudModelProvider.gd
+++ b/game/agent/model/OllamaCloudModelProvider.gd
@@ -1,0 +1,70 @@
+class_name OllamaCloudModelProvider
+extends "res://agent/model/OpenAICompatibleModelProvider.gd"
+
+
+const DEFAULT_ENDPOINT := "http://localhost:11434/v1/chat/completions"
+const GPT_OSS__20B_CLOUD_MODEL := "gpt-oss:20b-cloud"
+const GPT_OSS__120B_CLOUD_MODEL := "gpt-oss:120b-cloud"
+const GEMMA_V4__CLOUD_MODEL := "gemma4:cloud"
+const GEMMA_V4__31B_CLOUD_MODEL := "gemma4:31b-cloud"
+const DEFAULT_MODEL := GPT_OSS__20B_CLOUD_MODEL
+const MODEL_DESCRIPTORS := [
+	{"id": GPT_OSS__20B_CLOUD_MODEL, "label": "GPT-OSS - 20b (Ollama-Cloud)", "input_modalities": ["text"]},
+	{"id": GPT_OSS__120B_CLOUD_MODEL, "label": "GPT-OSS - 120b (Ollama-Cloud)", "input_modalities": ["text"]},
+	{"id": GEMMA_V4__CLOUD_MODEL, "label": "Gemma 4 - (Ollama-Cloud)", "input_modalities": ["text"]},
+	{"id": GEMMA_V4__31B_CLOUD_MODEL, "label": "Gemma 4 - 31b (Ollama-Cloud)", "input_modalities": ["text"]},
+]
+
+func _init(
+	request_host: Node = null,
+	transport: Object = null,
+	config: Dictionary = {},
+) -> void:
+	super(request_host, transport, config)
+
+
+func _provider_id() -> String:
+	return "ollama-cloud"
+
+
+func _provider_label() -> String:
+	return "Ollama-Cloud"
+
+
+func _transport_label() -> String:
+	return "Ollama-Cloud API"
+
+
+func _default_endpoint() -> String:
+	return DEFAULT_ENDPOINT
+
+
+func _default_model() -> String:
+	return DEFAULT_MODEL
+
+
+func _provider_request_options() -> Dictionary:
+	return {
+		"thinking": {"type": "disabled"},
+		"response_format": {"type": "json_object"},
+	}
+
+
+func validate_configuration() -> Array[String]:
+	var errors := super.validate_configuration()
+	var model_id := String(_config.get("model", DEFAULT_MODEL))
+	var support_models := [GPT_OSS__20B_CLOUD_MODEL, GPT_OSS__120B_CLOUD_MODEL, GEMMA_V4__CLOUD_MODEL, GEMMA_V4__31B_CLOUD_MODEL]
+	if model_id not in support_models:
+		errors.append("Ollama-Cloud Provider 不支持模型：%s" % model_id)
+	return errors
+
+
+func _api_key_environment_names() -> Array[String]:
+	return ["OLLAMA_CLOUD_API_KEY"]
+
+
+func _missing_api_key_message(include_hint: bool) -> String:
+	var message := "缺少 OLLAMA_CLOUD_API_KEY"
+	if include_hint:
+		message += "；可写入项目 .tmp/.env"
+	return message

--- a/game/agent/model/OllamaCloudModelProvider.gd.uid
+++ b/game/agent/model/OllamaCloudModelProvider.gd.uid
@@ -1,0 +1,1 @@
+uid://bg5xs4d1h11lq

--- a/game/agent/model/OllamaModelProvider.gd
+++ b/game/agent/model/OllamaModelProvider.gd
@@ -1,0 +1,70 @@
+class_name OllamaModelProvider
+extends "res://agent/model/OpenAICompatibleModelProvider.gd"
+
+
+const DEFAULT_ENDPOINT := "http://localhost:11434/v1/chat/completions"
+const QWEN_V3_5__0_8B_MODEL := "qwen3.5:0.8b"
+const QWEN_V3_5__2B_MODEL := "qwen3.5:2b"
+const QWEN_V3_5__4B_MODEL := "qwen3.5:4b"
+const QWEN_V3_5__9B_MODEL := "qwen3.5:9b"
+const DEFAULT_MODEL := QWEN_V3_5__2B_MODEL
+const MODEL_DESCRIPTORS := [
+	{"id": QWEN_V3_5__0_8B_MODEL, "label": "Qwen 2.5 - 0.8b (Ollama)", "input_modalities": ["text"]},
+	{"id": QWEN_V3_5__2B_MODEL, "label": "Qwen 2.5 - 2b (Ollama)", "input_modalities": ["text"]},
+	{"id": QWEN_V3_5__4B_MODEL, "label": "Qwen 2.5 - 4b (Ollama)", "input_modalities": ["text"]},
+	{"id": QWEN_V3_5__9B_MODEL, "label": "Qwen 2.5 - 9b (Ollama)", "input_modalities": ["text"]},
+]
+
+func _init(
+	request_host: Node = null,
+	transport: Object = null,
+	config: Dictionary = {},
+) -> void:
+	super(request_host, transport, config)
+
+
+func _provider_id() -> String:
+	return "ollama"
+
+
+func _provider_label() -> String:
+	return "Ollama"
+
+
+func _transport_label() -> String:
+	return "Ollama API"
+
+
+func _default_endpoint() -> String:
+	return DEFAULT_ENDPOINT
+
+
+func _default_model() -> String:
+	return DEFAULT_MODEL
+
+
+func _provider_request_options() -> Dictionary:
+	return {
+		"thinking": {"type": "disabled"},
+		"response_format": {"type": "json_object"},
+	}
+
+
+func validate_configuration() -> Array[String]:
+	var errors := super.validate_configuration()
+	var model_id := String(_config.get("model", DEFAULT_MODEL))
+	var support_models := [QWEN_V3_5__0_8B_MODEL, QWEN_V3_5__2B_MODEL, QWEN_V3_5__4B_MODEL, QWEN_V3_5__9B_MODEL]
+	if model_id not in support_models:
+		errors.append("Ollama Provider 不支持模型：%s" % model_id)
+	return errors
+
+
+func _api_key_environment_names() -> Array[String]:
+	return ["OLLAMA_API_KEY"]
+
+
+func _missing_api_key_message(include_hint: bool) -> String:
+	var message := "缺少 OLLAMA_API_KEY"
+	if include_hint:
+		message += "；可写入项目 .tmp/.env"
+	return message

--- a/game/agent/model/OllamaModelProvider.gd.uid
+++ b/game/agent/model/OllamaModelProvider.gd.uid
@@ -1,0 +1,1 @@
+uid://c4pymy3cefrmk


### PR DESCRIPTION
### 改动内容

- 在agent/model下添加了OllamaModelProvider.gd和OllamaCloudModelProvider.gd，分别管理Ollama本地模型和Ollama云模型。

目前支持的模型有：

**本地模型：**

1. qwen3.5:0.8b
2. qwen3.5:2b
3. qwen3.5:4b
4. qwen3.5:9b

**云模型：**

1. gpt-oss:20b-cloud
2. gpt-oss:120b-cloud
3. gemma4:cloud
4. gemma4:31b-cloud


- 修改了ModelProviderCatalog.gd以注册新的模型供应商。


### 本地测试

对Godot编辑器内的开发DEBUG环境、导出后的Windows x86_64 exe均进行了测试，Ollama本地模型和云模型均可以通过网络测试，并且在游戏内可以正常操控角色移动、工作、对话等，表现正常且稳定。