### PR TITLE
feat(provider-settings): 支持远程 HTTP 模型提供商并增加非加密传输警告

### DIFF
--- a/game/tests/agent/provider/offline/model_provider_catalog_test.gd
+++ b/game/tests/agent/provider/offline/model_provider_catalog_test.gd
@@ -821,13 +821,15 @@ func _test_local_endpoint_and_model_persistence() -> void:
 		["qwen3:8b", "gemma3:4b"],
 		"local model ids survive a config reload",
 	)
-	var unsafe_config := local_config.duplicate(true)
-	unsafe_config["providers"]["ollama"]["endpoint"] = "http://example.com/v1"
-	var rejected := store.call("save_config", unsafe_config) as Dictionary
+	var remote_http_config := local_config.duplicate(true)
+	remote_http_config["providers"]["ollama"]["endpoint"] = (
+		"http://example.com:3000/v1"
+	)
+	var remote_http_saved := store.call("save_config", remote_http_config) as Dictionary
 	_expect_equal(
-		rejected.get("ok"),
-		false,
-		"unencrypted remote compatible endpoints remain forbidden",
+		remote_http_saved.get("ok"),
+		true,
+		"unencrypted remote compatible endpoints can be persisted after warning",
 	)
 	var legacy_path := "%s/legacy-settings.json" % CONFIG_TEST_ROOT
 	var legacy_file := FileAccess.open(legacy_path, FileAccess.WRITE)
@@ -933,7 +935,7 @@ func _test_settings_service_custom_model_flow() -> void:
 		"provider_settings.save_connection",
 		{
 			"providerId": "openai-compatible",
-			"baseUrl": "https://compatible.example/v1",
+			"baseUrl": "http://compatible.example:3000/v1",
 			"apiKey": "temporary-test-key",
 		},
 	) as Dictionary
@@ -948,8 +950,8 @@ func _test_settings_service_custom_model_flow() -> void:
 	)
 	_expect_equal(
 		saved_remote_provider.get("baseUrl"),
-		"https://compatible.example/v1",
-		"combined connection save projects the normalized address",
+		"http://compatible.example:3000/v1",
+		"combined connection save accepts and projects a remote HTTP address",
 	)
 	_expect_equal(
 		(saved_remote_provider.get("key", {}) as Dictionary).get("saved"),

--- a/game/tests/town_ui_runtime_test.gd
+++ b/game/tests/town_ui_runtime_test.gd
@@ -3373,8 +3373,40 @@ func _scenario_ui_runtime_host_navigation() -> void:
 					rebuilt_base_url_edit,
 					"Provider refresh restores Base URL input focus",
 				)
+				var http_warning := provider_page.find_child(
+					"InsecureHttpWarning",
+					true,
+					false,
+				) as Label
+				_expect(
+					http_warning != null and not http_warning.visible,
+					"Provider route keeps the HTTP warning hidden without an HTTP URL",
+				)
+				var secure_base_url_width := rebuilt_base_url_edit.size.x
+				rebuilt_base_url_edit.text = "http://api.example.com:3000/v1"
+				rebuilt_base_url_edit.text_changed.emit(rebuilt_base_url_edit.text)
+				_expect(
+					http_warning != null
+					and http_warning.visible
+					and http_warning.text.contains("非加密传输"),
+					"Provider route warns only after entering an HTTP Base URL",
+				)
+				_expect(
+					http_warning != null
+					and is_equal_approx(
+						rebuilt_base_url_edit.size.x,
+						secure_base_url_width,
+					)
+					and http_warning.global_position.y + http_warning.size.y
+					<= rebuilt_base_url_edit.global_position.y + 1.0,
+					"Provider route places the HTTP warning above the full-width Base URL field",
+				)
 				rebuilt_base_url_edit.text = "https://api.deepseek.com"
 				rebuilt_base_url_edit.text_changed.emit(rebuilt_base_url_edit.text)
+				_expect(
+					http_warning != null and not http_warning.visible,
+					"Provider route hides the HTTP warning for an HTTPS Base URL",
+				)
 	await _verify_local_provider_url_autodiscovery(
 		provider_page as ProviderSettingsScreen,
 		"ollama",

--- a/game/ui/provider_settings/ProviderSettingsScreen.gd
+++ b/game/ui/provider_settings/ProviderSettingsScreen.gd
@@ -1919,6 +1919,8 @@ func _build_key_section(provider: Dictionary) -> Control:
 		_sync_key_save_enabled()
 	)
 	form.add_child(_key_edit)
+	if local_service:
+		column.add_child(_insecure_http_warning(_key_edit))
 
 	var actions := HBoxContainer.new()
 	actions.add_theme_constant_override("separation", 8)
@@ -2079,7 +2081,27 @@ func _build_base_url_section(provider: Dictionary) -> Control:
 		)
 	)
 	row.add_child(save)
+	column.add_child(_insecure_http_warning(_base_url_edit))
 	return panel
+
+
+func _insecure_http_warning(edit: LineEdit) -> Label:
+	var warning := Label.new()
+	warning.name = "InsecureHttpWarning"
+	warning.text = "您正在使用非加密传输（HTTP），数据在传输过程中可能被窃取。"
+	warning.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+	warning.add_theme_font_size_override("font_size", _caption_font_size())
+	warning.add_theme_color_override("font_color", ProviderTheme.WARNING)
+	warning.mouse_filter = Control.MOUSE_FILTER_IGNORE
+	warning.visible = _uses_insecure_http(edit.text)
+	edit.text_changed.connect(func(value: String) -> void:
+		warning.visible = _uses_insecure_http(value)
+	)
+	return warning
+
+
+func _uses_insecure_http(value: String) -> bool:
+	return value.strip_edges().to_lower().begins_with("http://")
 
 
 func _build_models_section(provider: Dictionary) -> Control:

--- a/game/ui/provider_settings/composite/ProviderSettingsCompositeDesktop.gd
+++ b/game/ui/provider_settings/composite/ProviderSettingsCompositeDesktop.gd
@@ -42,6 +42,7 @@ const CUSTOM_OTHER_BASE_LABEL_RECT := Rect2(690.0, 335.0, 116.0, 46.0)
 const CUSTOM_OTHER_BASE_INPUT_RECT := Rect2(814.0, 335.0, 608.0, 46.0)
 const CUSTOM_OTHER_KEY_LABEL_RECT := Rect2(690.0, 386.0, 116.0, 50.0)
 const CUSTOM_OTHER_KEY_INPUT_RECT := Rect2(814.0, 386.0, 430.0, 52.0)
+const CUSTOM_OTHER_HTTP_WARNING_RECT := Rect2(870.0, 296.0, 420.0, 35.0)
 const CUSTOM_OTHER_SAVE_RECT := Rect2(1306.0, 296.0, 116.0, 46.0)
 const CUSTOM_OTHER_REVEAL_RECT := Rect2(1258.0, 386.0, 76.0, 52.0)
 const CUSTOM_OTHER_DELETE_RECT := Rect2(1347.0, 386.0, 76.0, 52.0)
@@ -69,6 +70,7 @@ const CUSTOM_MODEL_CARD_Y := 630.0
 const CUSTOM_MODEL_CARD_HEIGHT := 106.0
 const CUSTOM_MODEL_NAME_Y := 637.0
 const CUSTOM_MODEL_ORIGIN_Y := 681.0
+const BASE_URL_HTTP_WARNING_RECT := Rect2(838.0, 428.0, 566.0, 39.0)
 const STANDARD_DYNAMIC_MODEL_INPUT_RECT := Rect2(850.0, 548.0, 300.0, 42.0)
 const STANDARD_DYNAMIC_MODEL_ADD_RECT := Rect2(1160.0, 544.0, 125.0, 50.0)
 const STANDARD_DYNAMIC_MODEL_PREVIOUS_RECT := Rect2(1290.0, 548.0, 38.0, 38.0)
@@ -1074,6 +1076,12 @@ func _build_custom_connection_section(
 			"custom_base_url_input",
 		)
 		_configure_custom_base_url_edit(provider, base_url_edit)
+		_add_insecure_http_warning(
+			owner,
+			region_rect,
+			CUSTOM_OTHER_HTTP_WARNING_RECT,
+			base_url_edit,
+		)
 		_build_custom_connection_label(
 			owner,
 			region_rect,
@@ -1500,6 +1508,41 @@ func _configure_custom_base_url_edit(
 	edit.text_changed.connect(func(value: String) -> void:
 		ui_action.emit(&"ui.draft_base_url", {"value": value})
 	)
+
+
+func _add_insecure_http_warning(
+	parent: Control,
+	parent_rect: Rect2,
+	source_rect: Rect2,
+	edit: LineEdit,
+) -> Label:
+	var warning := Label.new()
+	warning.name = "InsecureHttpWarning"
+	warning.text = "您正在使用非加密传输（HTTP），数据在传输过程中可能被窃取。"
+	_place(warning, _scaled_rect(source_rect), parent_rect)
+	warning.vertical_alignment = VERTICAL_ALIGNMENT_CENTER
+	warning.add_theme_font_override(
+		"font",
+		ProviderTheme.composite_font("small"),
+	)
+	warning.add_theme_font_size_override("font_size", _scaled_font_size(15))
+	warning.add_theme_color_override(
+		"font_color",
+		ProviderTheme.COMPOSITE_WARNING,
+	)
+	warning.mouse_filter = Control.MOUSE_FILTER_IGNORE
+	warning.add_to_group("provider_settings_text_slot")
+	warning.set_meta("gate_id", "insecure_http_warning")
+	parent.add_child(warning)
+	warning.visible = _uses_insecure_http(edit.text)
+	edit.text_changed.connect(func(value: String) -> void:
+		warning.visible = _uses_insecure_http(value)
+	)
+	return warning
+
+
+func _uses_insecure_http(value: String) -> bool:
+	return value.strip_edges().to_lower().begins_with("http://")
 
 
 func _configure_custom_key_edit(
@@ -2123,6 +2166,12 @@ func _build_base_url_section(
 	base_url_edit.placeholder_text = _base_url_placeholder(provider, custom_group)
 	base_url_edit.text_changed.connect(func(value: String) -> void:
 		ui_action.emit(&"ui.draft_base_url", {"value": value})
+	)
+	_add_insecure_http_warning(
+		owner,
+		region_rect,
+		BASE_URL_HTTP_WARNING_RECT,
+		base_url_edit,
 	)
 	base_url_edit.text_submitted.connect(func(value: String) -> void:
 		if custom_group:

--- a/game/ui/save_feedback/save_feedback_cancellation.json
+++ b/game/ui/save_feedback/save_feedback_cancellation.json
@@ -3,35 +3,35 @@
   "status": "active_decision",
   "decidedAt": "2026-07-20",
   "cancelled": {
-    "surface": "standalone_save_unavailable_full_page",
-    "reason": "duplicates_pause_menu_save_unavailable_card_and_disabled_actions",
-    "runtimeConsumable": false,
-    "navigationAllowed": false
+	"surface": "standalone_save_unavailable_full_page",
+	"reason": "duplicates_pause_menu_save_unavailable_card_and_disabled_actions",
+	"runtimeConsumable": false,
+	"navigationAllowed": false
   },
   "singleOwner": {
-    "currentUnavailableCapabilityMessage": "ui.pause-menu.save-card",
-    "saveFeedbackWhenFormalReady": [
-      "autosave_loading_toast",
-      "save_success_toast",
-      "save_failure_retry_feedback",
-      "restore_blocking_feedback",
-      "version_migration_blocking_feedback",
-      "crash_recovery_blocking_feedback",
+	"currentUnavailableCapabilityMessage": "ui.pause-menu.save-card",
+	"saveFeedbackWhenFormalReady": [
+	  "autosave_loading_toast",
+	  "save_success_toast",
+	  "save_failure_retry_feedback",
+	  "restore_blocking_feedback",
+	  "version_migration_blocking_feedback",
+	  "crash_recovery_blocking_feedback",
       "save_before_return_to_menu_feedback"
-    ]
+	]
   },
   "retained": [
 		"responsive_blueprint_and_state_matrix_in_page_record",
     "candidate_artifacts_as_non_consumable_history"
   ],
   "removed": [
-    "SaveFeedbackLayer.gd",
-    "SaveFeedbackLayer.tscn",
-    "tests/runtime_gate_and_capture",
+	"SaveFeedbackLayer.gd",
+	"SaveFeedbackLayer.tscn",
+	"tests/runtime_gate_and_capture",
     "runtime_manifest_and_ownership_audit"
   ],
   "retiredEvidence": [
-    "assets/ui/save_feedback/final/*.png",
+	"assets/ui/save_feedback/final/*.png",
     "assets/ui/save_feedback/final/runtime_proof/*.png"
   ],
   "formalReady": false

--- a/game/world/presentation/ui/TownProviderConfigStore.gd
+++ b/game/world/presentation/ui/TownProviderConfigStore.gd
@@ -356,6 +356,7 @@ func _display_name_is_valid(display_name: String) -> bool:
 
 
 func _endpoint_is_valid(endpoint: String) -> bool:
+	# HTTP 与 HTTPS 都是可保存的显式选择；HTTP 风险由设置页实时提示。
 	var scheme := ""
 	if endpoint.begins_with("https://"):
 		scheme = "https://"
@@ -400,8 +401,6 @@ func _endpoint_is_valid(endpoint: String) -> bool:
 			port = authority.substr(colon_index + 1)
 	if host.is_empty() or host.begins_with(".") or host.ends_with("."):
 		return false
-	if scheme == "http://" and not _loopback_host_is_valid(host):
-		return false
 	if host.begins_with("["):
 		var address := host.substr(1, host.length() - 2)
 		if not address.is_valid_ip_address():
@@ -441,13 +440,6 @@ func _endpoint_is_valid(endpoint: String) -> bool:
 	elif authority.ends_with(":"):
 		return false
 	return true
-
-
-func _loopback_host_is_valid(host: String) -> bool:
-	var normalized := host.to_lower()
-	if normalized == "localhost" or normalized == "[::1]":
-		return true
-	return normalized.begins_with("127.") and _canonical_ipv4_is_valid(normalized)
 
 
 func _canonical_ipv4_is_valid(host: String) -> bool:

--- a/game/world/presentation/ui/TownProviderSettingsService.gd
+++ b/game/world/presentation/ui/TownProviderSettingsService.gd
@@ -1777,20 +1777,8 @@ func _stored_api_models(provider: Dictionary) -> Array[String]:
 
 
 func _base_url_scheme_is_allowed(endpoint: String) -> bool:
-	if endpoint.begins_with("https://"):
-		return true
-	if not endpoint.begins_with("http://"):
-		return false
-	var authority := endpoint.trim_prefix("http://").split("/", false)[0]
-	var host := authority
-	if authority.begins_with("["):
-		var closing := authority.find("]")
-		if closing < 0:
-			return false
-		host = authority.left(closing + 1)
-	elif authority.contains(":"):
-		host = authority.get_slice(":", 0)
-	return host.to_lower() in ["localhost", "127.0.0.1", "[::1]"]
+	# 远程 HTTP 由设置页明确警告风险，但不再阻止玩家保存。
+	return endpoint.begins_with("https://") or endpoint.begins_with("http://")
 
 
 func _masked_key(api_key: String) -> String:
@@ -2188,7 +2176,7 @@ func _player_message_for_error_code(code: String) -> String:
 		"PROVIDER_DISABLED":
 			return "当前 Provider 已停用。请先启用，再检查连接。"
 		"PROVIDER_BASE_URL_INVALID":
-			return "Base URL 必须使用 HTTPS；本机服务可使用 localhost 的 HTTP 地址。"
+			return "Base URL 必须以 http:// 或 https:// 开头。"
 		"PROVIDER_AUTH_FAILED":
 			return "API Key 未通过认证。请重新输入并保存 Key，然后重试。"
 		"PROVIDER_BILLING_FAILED":


### PR DESCRIPTION
## 简述

此前程序仅支持远程 HTTPS 模型提供商；HTTP 仅允许用于 localhost 等本地服务。设置界面没有显著说明这一限制，用户配置未启用 SSL 的远程模型服务时，只会遇到连接或模型读取失败，难以判断具体原因。

本次改进允许用户配置和使用远程 HTTP 模型提供商，同时在界面上明确提示非加密传输风险。

## 修改范围

- 放开远程 HTTP Base URL 的保存和持久化限制。
- 保留 Base URL 的地址格式与端口合法性校验。
- 当用户输入以 `http://` 开头的 Base URL 时，在输入框上方显示提示：
  “您正在使用非加密传输（HTTP），数据在传输过程中可能被窃取。”
- 提示仅在使用 HTTP 时显示；切换到 HTTPS 或清空地址后自动隐藏。
- 保持原有布局不变。
- 补充远程 HTTP 配置保存、连接设置以及警告显示与隐藏行为的测试。

## 效果

<img width="1920" height="1080" alt="QQ_1786463024486" src="https://github.com/user-attachments/assets/763818e2-96b9-4799-b4fd-ce2ae68235f2" />
