### PR TITLE
修复居民详情屏焦点管理在控件重建时的崩溃

### DIFF
--- a/game/ui/resident_detail/ResidentDetailScreen.gd
+++ b/game/ui/resident_detail/ResidentDetailScreen.gd
@@ -455,7 +455,12 @@ func _unhandled_input(event: InputEvent) -> void:
 				var next_tab := _tab_buttons.get(
 					TAB_IDS[next_index]
 				) as Control
-				if next_tab != null and next_tab.focus_mode != Control.FOCUS_NONE:
+				if (
+					next_tab != null
+					and is_instance_valid(next_tab)
+					and next_tab.is_inside_tree()
+					and next_tab.focus_mode != Control.FOCUS_NONE
+				):
 					next_tab.grab_focus()
 					break
 			get_viewport().set_input_as_handled()
@@ -594,11 +599,21 @@ func focus_default() -> void:
 		_render_data.get("selectedTab", "status")
 	)
 	var tab := _tab_buttons.get(selected_tab) as Control
-	if tab != null and tab.focus_mode != Control.FOCUS_NONE:
+	if (
+		tab != null
+		and is_instance_valid(tab)
+		and tab.is_inside_tree()
+		and tab.focus_mode != Control.FOCUS_NONE
+	):
 		tab.grab_focus.call_deferred()
 		return
 	for control: Control in _focus_controls:
-		if control.visible and control.focus_mode != Control.FOCUS_NONE:
+		if (
+			is_instance_valid(control)
+			and control.is_inside_tree()
+			and control.visible
+			and control.focus_mode != Control.FOCUS_NONE
+		):
 			control.grab_focus.call_deferred()
 			return
 
@@ -3125,8 +3140,17 @@ func _apply_focus_neighbors() -> void:
 		return
 	for index: int in _focus_controls.size():
 		var current := _focus_controls[index]
+		if not is_instance_valid(current) or not current.is_inside_tree():
+			continue
 		var previous := _focus_controls[posmod(index - 1, _focus_controls.size())]
 		var next := _focus_controls[(index + 1) % _focus_controls.size()]
+		if (
+			not is_instance_valid(previous)
+			or not previous.is_inside_tree()
+			or not is_instance_valid(next)
+			or not next.is_inside_tree()
+		):
+			continue
 		current.focus_neighbor_top = current.get_path_to(previous)
 		current.focus_neighbor_left = current.get_path_to(previous)
 		current.focus_neighbor_bottom = current.get_path_to(next)
@@ -3141,15 +3165,23 @@ func _move_focus(direction: int) -> void:
 	if index < 0:
 		focus_default()
 		return
-	_focus_controls[posmod(index + direction, _focus_controls.size())].grab_focus()
+	var target := _focus_controls[posmod(index + direction, _focus_controls.size())]
+	if not is_instance_valid(target) or not target.is_inside_tree():
+		focus_default()
+		return
+	target.grab_focus()
 
 
 func _focused_semantic() -> String:
 	var focused := get_viewport().gui_get_focus_owner()
+	if focused == null or not is_instance_valid(focused):
+		return ""
 	for tab_id: String in TAB_IDS:
 		if _tab_buttons.get(tab_id) == focused:
 			return "tab:%s" % tab_id
-	var filter_index := _section_filter_buttons.find(focused)
+	var filter_index := -1
+	if focused is Button:
+		filter_index = _section_filter_buttons.find(focused)
 	if filter_index >= 0:
 		return "filter:%d" % filter_index
 	var row_index := _row_controls.find(focused)
@@ -3186,6 +3218,8 @@ func _restore_semantic_focus(semantic: String) -> void:
 		target = _close_button
 	if (
 		target != null
+		and is_instance_valid(target)
+		and target.is_inside_tree()
 		and target.visible
 		and target.focus_mode != Control.FOCUS_NONE
 	):


### PR DESCRIPTION
## 问题

macOS 上游戏连续两次崩溃(见 DiagnosticReports:`我的ai小镇-2026-08-17-002029.ips` 与 `002315.ips`),两次崩溃栈**完全一致**:

- `EXC_BAD_ACCESS (SIGSEGV)`,读取地址 `0x34`(空指针 + 偏移)
- 崩溃线程为主线程,栈深处 `0x328cc98 ↔ 0xb8d8d4 ↔ 0xb8d8f0` 交替出现 10 次——典型的 GDScript VM 调用帧 + 信号回调形成的**深层递归**
- 崩溃前日志反复刷屏:

```
ERROR: Attempted to find an object of type 'Control' into a TypedArray, which does not inherit from 'Button'.
   at: _internal_validate_object (./core/variant/container_type_validate.h:115)
ERROR: Condition "!_p->typed.validate(value, \"find\")" is true. Returning: -1
   at: find (core/variant/array.cpp:374)
ERROR: Condition "!is_inside_tree()" is true. Returning: Rect2()
   at: get_viewport_rect (scene/main/canvas_item.cpp:1231)
```

## 根因

崩溃位于 `game/ui/resident_detail/ResidentDetailScreen.gd` 的焦点语义/恢复路径:

1. 数据刷新(`apply_snapshot`)或操作反馈(`_present_local_feedback`)时先调用 `_focused_semantic()` 记录焦点,随后 `_render()` 重建控件,再 `_restore_semantic_focus.call_deferred()` 在下一帧恢复焦点。
2. `_focused_semantic()` 里 `_section_filter_buttons.find(focused)` —— `_section_filter_buttons` 是 `Array[Button]`,而 `focused` 是 `gui_get_focus_owner()` 返回的任意 `Control`;焦点落在非 Button 控件上时,每次调用都触发 TypedArray 类型校验失败(即日志中刷屏的 `find` 错误)。
3. 控件重建期间,`_apply_focus_neighbors()` 对**已离树/已释放**的控件调用 `get_path_to()`(日志中 `!is_inside_tree()` 错误),`_restore_semantic_focus()` / `_move_focus()` / `focus_default()` 对无效控件调用 `grab_focus()`。无效对象上的操作进入深层递归后,最终空指针解引用崩溃。

## 修复

在全部焦点操作前补充 `is_instance_valid()` + `is_inside_tree()` 守卫,并把 `_section_filter_buttons.find()` 限定为 `focused is Button` 时执行,消除类型校验刷屏与无效对象访问:

- `_apply_focus_neighbors()`:跳过无效/离树控件,`get_path_to` 前校验邻居
- `_move_focus()`:目标控件无效时回退 `focus_default()`
- `_focused_semantic()`:`focused` 无效直接返回空;`find` 前限定类型
- `_restore_semantic_focus()`:`grab_focus` 前校验 `is_instance_valid` + `is_inside_tree`
- `focus_default()` / tab 切换:同样补齐守卫

行为不变:控件有效时焦点逻辑与之前完全一致;控件无效时安全跳过或回退默认焦点,不再访问无效对象。

## 验证

- 本地 `tools/guards/run_guards.sh`:`GUARDS_PASS`(行数棘轮、动态调用、零引用、必测清单、预加载资源、跨平台文本、着色器、README 同步、发行工具全部通过)
- 改动仅 1 个文件,+39 / -5,不涉及其他模块